### PR TITLE
chore(ui): 글자 수에 따라서 textarea 높이가 늘어나게 조정

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,13 +1,6 @@
 {
     "editor.formatOnSave": false,
     "editor.codeActionsOnSave": {
-      "source.fixAll.eslint": "explicit"
-    },
-    "[typescript]": {
-      "editor.defaultFormatter": "esbenp.prettier-vscode"
-    },
-    "[json]": {
-      "editor.defaultFormatter": "esbenp.prettier-vscode",
-    },  
-    "workbench.settings.useSplitJSON": true 
+      "source.fixAll.eslint": true
+    }
   }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -20,6 +20,7 @@
     "@storybook/react": "^7.6.6",
     "@storybook/react-vite": "^7.6.6",
     "@storybook/test": "^7.6.6",
+    "@types/lodash": "^4.14.202",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
     "eslint-plugin-storybook": "^0.6.15",
@@ -30,6 +31,7 @@
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "@sickgyun/design-token": "workspace:*",
+    "lodash": "^4.17.21",
     "next": "14.0.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/packages/ui/src/Textarea/Textarea.stories.tsx
+++ b/packages/ui/src/Textarea/Textarea.stories.tsx
@@ -4,6 +4,14 @@ import { Textarea as TextareaComponent } from '.';
 type Textarea = typeof TextareaComponent;
 
 const meta: Meta<Textarea> = {
+  argTypes: {
+    isAutoHeight: {
+      control: { type: 'boolean' },
+    },
+    minHeight: {
+      control: { type: 'text' },
+    },
+  },
   component: TextareaComponent,
   title: 'Components/Textarea',
 };
@@ -15,6 +23,7 @@ export const Default: StoryObj<Textarea> = {
     label: '라벨임',
     placeholder: '플레이스 홀더임',
     width: '358px',
+    isAutoHeight: false,
   },
   render: (args) => <TextareaComponent {...args} />,
 };

--- a/packages/ui/src/Textarea/index.tsx
+++ b/packages/ui/src/Textarea/index.tsx
@@ -50,7 +50,7 @@ const StyledTextarea = styled.textarea<TextareaProps>`
   padding: 12px 16px;
   border-radius: 16px;
   width: 100%;
-  min-height: 150px;
+  min-height: 300px;
   font-size: 15px;
   ${({ theme }) => css`
     border: 1.5px solid ${theme.colors.gray400};

--- a/packages/ui/src/Textarea/index.tsx
+++ b/packages/ui/src/Textarea/index.tsx
@@ -9,33 +9,40 @@ type TextareaProps = {
   label?: string;
   width?: string;
   minHeight?: string;
+  isAutoHeight?: boolean;
 } & TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 export const Textarea = forwardRef(function Textarea(
-  { label, width = '100%', minHeight = '150px', onChange, ...props }: TextareaProps,
+  {
+    label,
+    width = '100%',
+    minHeight = '150px',
+    isAutoHeight = false,
+    onChange,
+    ...props
+  }: TextareaProps,
   ref: ForwardedRef<HTMLTextAreaElement>
 ) {
-  const handleInput = useCallback(
+  const handleTextareaHeightChange = useCallback(
     debounce((e: ChangeEvent<HTMLTextAreaElement>) => {
       e.target.style.height = 'inherit';
       e.target.style.height = `${e.target.scrollHeight}px`;
     }, 300),
-    []
+    [debounce]
   );
 
   return (
     <StyledTextareaWrapper width={width}>
       {label && (
-        <Text color="gray600" fontType="body3" style={{ marginBottom: '8px' }}>
+        <Text color="gray600" fontType="p3" style={{ marginBottom: '8px' }}>
           {label}
         </Text>
       )}
       <StyledTextarea
         ref={ref}
-        label={label}
         minHeight={minHeight}
         onChange={onChange}
-        onInput={handleInput}
+        onInput={isAutoHeight ? handleTextareaHeightChange : undefined}
         {...props}
       />
     </StyledTextareaWrapper>
@@ -49,7 +56,7 @@ const StyledTextareaWrapper = styled.div<{ width?: string }>`
   width: ${({ width }) => width};
 `;
 
-const StyledTextarea = styled.textarea<TextareaProps>`
+const StyledTextarea = styled.textarea<{ minHeight?: string }>`
   resize: none;
   outline: none;
   padding: 12px 16px;

--- a/packages/ui/src/Textarea/index.tsx
+++ b/packages/ui/src/Textarea/index.tsx
@@ -17,7 +17,6 @@ export const Textarea = forwardRef(function Textarea(
 ) {
   const handleInput = useCallback(
     debounce((e: ChangeEvent<HTMLTextAreaElement>) => {
-      console.log('Input event debounced!');
       e.target.style.height = 'inherit';
       e.target.style.height = `${e.target.scrollHeight}px`;
     }, 300),

--- a/packages/ui/src/Textarea/index.tsx
+++ b/packages/ui/src/Textarea/index.tsx
@@ -59,7 +59,7 @@ const StyledTextareaWrapper = styled.div<{ width?: string }>`
 const StyledTextarea = styled.textarea<{ minHeight?: string }>`
   resize: none;
   outline: none;
-  padding: 12px 16px;
+  padding: 10px 16px;
   border-radius: 16px;
   width: 100%;
   min-height: ${({ minHeight }) => minHeight};

--- a/packages/ui/src/Textarea/index.tsx
+++ b/packages/ui/src/Textarea/index.tsx
@@ -13,14 +13,26 @@ export const Textarea = forwardRef(function Textarea(
   { label, width = '100%', onChange, ...props }: TextareaProps,
   ref: ForwardedRef<HTMLTextAreaElement>
 ) {
+  const handleInput = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    e.target.style.height = 'inherit';
+    e.target.style.height = `${e.target.scrollHeight}px`;
+  };
+
   return (
     <StyledTextareaWrapper width={width}>
       {label && (
-        <Text color="gray600" fontType="p3" style={{ marginBottom: '8px' }}>
+        <Text color="gray600" fontType="body3" style={{ marginBottom: '8px' }}>
           {label}
         </Text>
       )}
-      <StyledTextarea ref={ref} label={label} onChange={onChange} {...props} />
+      <StyledTextarea
+        ref={ref}
+        label={label}
+        onChange={onChange}
+        onInput={handleInput}
+        {...props}
+        rows={1}
+      />
     </StyledTextareaWrapper>
   );
 });
@@ -35,10 +47,11 @@ const StyledTextareaWrapper = styled.div<{ width?: string }>`
 const StyledTextarea = styled.textarea<TextareaProps>`
   resize: none;
   outline: none;
-  padding: 10px 16px;
+  padding: 12px 16px;
   border-radius: 16px;
   width: 100%;
-  height: 150px;
+  min-height: 150px;
+  font-size: 15px;
   ${({ theme }) => css`
     border: 1.5px solid ${theme.colors.gray400};
     background-color: ${theme.colors.white};
@@ -51,5 +64,5 @@ const StyledTextarea = styled.textarea<TextareaProps>`
     &:focus {
       border: 1.5px solid ${theme.colors.primary};
     }
-  `}
+  `};
 `;

--- a/packages/ui/src/Textarea/index.tsx
+++ b/packages/ui/src/Textarea/index.tsx
@@ -1,23 +1,28 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
-import type { ForwardedRef, TextareaHTMLAttributes } from 'react';
-import { forwardRef } from 'react';
+import type { ChangeEvent, ForwardedRef, TextareaHTMLAttributes } from 'react';
+import { forwardRef, useCallback } from 'react';
 import { Text } from '../Text';
+import { debounce } from 'lodash';
 
 type TextareaProps = {
   label?: string;
   width?: string;
-  height?: string;
+  minHeight?: string;
 } & TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 export const Textarea = forwardRef(function Textarea(
-  { label, width = '100%', height = '150px', onChange, ...props }: TextareaProps,
+  { label, width = '100%', minHeight = '150px', onChange, ...props }: TextareaProps,
   ref: ForwardedRef<HTMLTextAreaElement>
 ) {
-  const handleInput = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    e.target.style.height = 'inherit';
-    e.target.style.height = `${e.target.scrollHeight}px`;
-  };
+  const handleInput = useCallback(
+    debounce((e: ChangeEvent<HTMLTextAreaElement>) => {
+      console.log('Input event debounced!');
+      e.target.style.height = 'inherit';
+      e.target.style.height = `${e.target.scrollHeight}px`;
+    }, 300),
+    []
+  );
 
   return (
     <StyledTextareaWrapper width={width}>
@@ -29,11 +34,10 @@ export const Textarea = forwardRef(function Textarea(
       <StyledTextarea
         ref={ref}
         label={label}
-        height={height}
+        minHeight={minHeight}
         onChange={onChange}
         onInput={handleInput}
         {...props}
-        rows={1}
       />
     </StyledTextareaWrapper>
   );
@@ -52,7 +56,7 @@ const StyledTextarea = styled.textarea<TextareaProps>`
   padding: 12px 16px;
   border-radius: 16px;
   width: 100%;
-  min-height: ${({ height }) => height};
+  min-height: ${({ minHeight }) => minHeight};
   font-size: 15px;
   ${({ theme }) => css`
     border: 1.5px solid ${theme.colors.gray400};

--- a/packages/ui/src/Textarea/index.tsx
+++ b/packages/ui/src/Textarea/index.tsx
@@ -7,10 +7,11 @@ import { Text } from '../Text';
 type TextareaProps = {
   label?: string;
   width?: string;
+  height?: string;
 } & TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 export const Textarea = forwardRef(function Textarea(
-  { label, width = '100%', onChange, ...props }: TextareaProps,
+  { label, width = '100%', height = '150px', onChange, ...props }: TextareaProps,
   ref: ForwardedRef<HTMLTextAreaElement>
 ) {
   const handleInput = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
@@ -28,6 +29,7 @@ export const Textarea = forwardRef(function Textarea(
       <StyledTextarea
         ref={ref}
         label={label}
+        height={height}
         onChange={onChange}
         onInput={handleInput}
         {...props}
@@ -50,7 +52,7 @@ const StyledTextarea = styled.textarea<TextareaProps>`
   padding: 12px 16px;
   border-radius: 16px;
   width: 100%;
-  min-height: 300px;
+  min-height: ${({ height }) => height};
   font-size: 15px;
   ${({ theme }) => css`
     border: 1.5px solid ${theme.colors.gray400};

--- a/packages/ui/src/Textarea/index.tsx
+++ b/packages/ui/src/Textarea/index.tsx
@@ -1,9 +1,9 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
+import { debounce } from 'lodash';
 import type { ChangeEvent, ForwardedRef, TextareaHTMLAttributes } from 'react';
 import { forwardRef, useCallback } from 'react';
 import { Text } from '../Text';
-import { debounce } from 'lodash';
 
 type TextareaProps = {
   label?: string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -333,6 +333,9 @@ importers:
       '@sickgyun/design-token':
         specifier: workspace:*
         version: link:../design-token
+      lodash:
+        specifier: ^4.17.21
+        version: 4.17.21
       next:
         specifier: 14.0.2
         version: 14.0.2(@babel/core@7.23.6)(react-dom@18.2.0)(react@18.2.0)
@@ -373,6 +376,9 @@ importers:
       '@storybook/test':
         specifier: ^7.6.6
         version: 7.6.6(@types/jest@29.5.11)(jest@29.7.0)
+      '@types/lodash':
+        specifier: ^4.14.202
+        version: 4.14.202
       '@types/react':
         specifier: ^18.2.0
         version: 18.2.13
@@ -10469,7 +10475,6 @@ packages:
 
   /lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
-    dev: true
 
   /log-symbols@4.1.0:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}


### PR DESCRIPTION
## ⛳️작업 내용

- 글자 수에 따라 textarea의 높이가 늘어나게 해야함

## 📸스크린샷

<img width="375" alt="스크린샷 2024-01-19 오후 4 37 48" src="https://github.com/sickgyun/sickgyun-client/assets/102288397/31f3cbb0-5bff-4858-9979-a379cfd75703">

<img width="393" alt="스크린샷 2024-01-19 오후 4 38 21" src="https://github.com/sickgyun/sickgyun-client/assets/102288397/a8dc7856-7d1f-4495-b5bb-58b6dd530c86">

## 📎레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->
