### PR TITLE
fix(client): 로그인 상태에서 페이지를 새로고침할 때 로그인 경고창이 나타나는 문제 수정

### DIFF
--- a/apps/client/src/hocs/withAuth.tsx
+++ b/apps/client/src/hocs/withAuth.tsx
@@ -1,19 +1,25 @@
 import { useOverlay } from '@toss/use-overlay';
-import type { ReactNode } from 'react';
+import { type ReactNode, useEffect, useState } from 'react';
 import AuthAlert from '@/components/common/AuthAlert';
-import { useUser } from '@/hooks/common/useUser';
+import { LOCAL_STORAGE_KEY } from '@/constants/storage';
+import { Storage } from '@/libs/api/storage';
 
 export const withAuth = (Component: () => ReactNode) => {
   const WrappedComponent = () => {
     const overlay = useOverlay();
-    const { user } = useUser();
+    const [mounted, setMounted] = useState(false);
+    const isLogin = Boolean(Storage.getItem(LOCAL_STORAGE_KEY.accessToken));
+
+    useEffect(() => {
+      setMounted(true);
+    }, []);
 
     const openAuthAlert = () => {
       overlay.open(({ isOpen, close }) => <AuthAlert isOpen={isOpen} onClose={close} />);
     };
 
     if (typeof window !== 'undefined') {
-      if (user.isLogin) {
+      if (mounted && isLogin) {
         return <Component />;
       } else {
         openAuthAlert();


### PR DESCRIPTION
## ⛳️작업 내용
- 로그인 상태에서 페이지를 새로고침할 때 로그인 경고창이 나타나는 문제 수정
  - 새로고침시 user에 기본으로 주었던 initial data가 반영되기 때문에 initial data에 isLogin은 false이기 때문에 생기는 이슈였어요 해당 이슈를 새로고침에도 영향이 없는 localStorage에 accessToken의 여부를 통해 검사하는 로직으로 바꾸어 해결하였어요.
<!-- 작업한 사항을 간략하게 적어주세요 -->

## 📸스크린샷

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## 📎레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->
