### PR TITLE
feat(client): 메인 페이지에 다이렉트 프로필 리스트 섹션 추가

### DIFF
--- a/apps/client/src/app/page.tsx
+++ b/apps/client/src/app/page.tsx
@@ -10,13 +10,16 @@ import Footer from '@/components/common/Footer';
 import Header from '@/components/common/Header';
 import LoginBox from '@/components/main/LoginBox';
 import MainBanner from '@/components/main/MainBanner';
+import DirectProfileList from '@/components/profile/DirectProfileList';
 import RecuritList from '@/components/recurit/RecuritList';
 import { MAJOR_LIST, RECRUIT_FULL_VIEW_LINK } from '@/constants/profile';
+import { useUser } from '@/hooks/common/useUser';
 import { LogClickEvent } from '@/libs/logging';
 import type { Major } from '@/types/profile';
 
 const MainPage = () => {
   const router = useRouter();
+  const { user } = useUser();
 
   const renderBanners = () => {
     return [<ErrorReportBanner />, <UserInterviewBanner />];
@@ -61,6 +64,15 @@ const MainPage = () => {
             <QnaBanner />
           </Stack>
           <Spacer height={64} /> */}
+          <Stack spacing={18}>
+            <Text fontType="h3">
+              {user.isLogin
+                ? `${user.name}님의 커피챗 신청을 기다리는 선배들이에요`
+                : '커피챗 신청을 기다리는 선배들이에요'}
+            </Text>
+            <DirectProfileList />
+          </Stack>
+          <Spacer height={64} />
           <Stack spacing={18} style={{ position: 'relative' }}>
             <Flex align="center" justify="space-between">
               <Text fontType="h3">채용 중인 회사에요!</Text>

--- a/apps/client/src/components/profile/DirectProfileCard/index.tsx
+++ b/apps/client/src/components/profile/DirectProfileCard/index.tsx
@@ -1,0 +1,103 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+import { IconChevronRightFill } from '@seed-design/icon';
+import { colors } from '@sickgyun/design-token';
+import { Flex, Stack, Text } from '@sickgyun/ui';
+import { useOverlay } from '@toss/use-overlay';
+import Image from 'next/image';
+import ProfileDetailModal from '../ProfileDetailModal';
+import { textEllipsis } from '@/emotion';
+import { useGetProfile } from '@/hooks/api/profile/useGetProfile';
+import { useUser } from '@/hooks/common/useUser';
+import { useLogAnalyticsEvent } from '@/libs/logging';
+import { useToast } from '@/libs/toast';
+import { convertNewlineToJSX } from '@/utils/convertNewlineToJsx';
+
+type DirectProfileCardProps = {
+  profileId: number;
+  userId: number;
+  introduction: string;
+};
+
+const DirectProfileCard = ({
+  profileId,
+  userId,
+  introduction,
+}: DirectProfileCardProps) => {
+  const overlay = useOverlay();
+  const { toast } = useToast();
+  const { user } = useUser();
+  const { logClickEvent } = useLogAnalyticsEvent();
+  const { profile } = useGetProfile(profileId);
+
+  const openProfileDetailModal = () => {
+    if (!user.isLogin) {
+      toast.error('로그인이 필요한 서비스에요.');
+      return;
+    }
+
+    logClickEvent({ name: 'click_direct_profile_card' });
+    overlay.open(({ isOpen, close }) => (
+      <ProfileDetailModal
+        isOpen={isOpen}
+        onClose={close}
+        profileId={profileId}
+        userId={userId}
+      />
+    ));
+  };
+
+  return (
+    <StyledDirectProfileCard onClick={openProfileDetailModal}>
+      <Stack
+        direction="horizontal"
+        align="center"
+        spacing={12}
+        style={{ marginBottom: '14px' }}
+      >
+        <StyledProfileImage src={profile.imageUrl} width={56} height={56} alt="Profile" />
+        <Stack
+          direction="vertical"
+          align="flex-start"
+          spacing={6}
+          style={{ width: '100%' }}
+        >
+          <Flex align="center" justify="space-between" style={{ width: '100%' }}>
+            <Text fontType="body1">{profile.name}</Text>
+            <IconChevronRightFill width={18} height={18} color={colors.gray900} />
+          </Flex>
+          <Text fontType="body3" color="gray600">
+            {profile.cardinal}기 • {profile.major}
+          </Text>
+        </Stack>
+      </Stack>
+      <StyledIntroduction fontType="p2" color="gray600">
+        {convertNewlineToJSX(introduction)}
+      </StyledIntroduction>
+    </StyledDirectProfileCard>
+  );
+};
+
+export default DirectProfileCard;
+
+const StyledDirectProfileCard = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: calc(100% / 4 - 15px);
+  height: 100%;
+  border-radius: 8px;
+  padding: 16px;
+  cursor: pointer;
+  ${({ theme }) => css`
+    border: 1px solid ${theme.colors.gray100};
+  `}
+`;
+
+const StyledProfileImage = styled(Image)`
+  border-radius: 8px;
+  object-fit: cover;
+`;
+
+const StyledIntroduction = styled(Text)`
+  ${textEllipsis}
+`;

--- a/apps/client/src/components/profile/DirectProfileList/index.tsx
+++ b/apps/client/src/components/profile/DirectProfileList/index.tsx
@@ -1,0 +1,38 @@
+import styled from '@emotion/styled';
+import { Stack } from '@sickgyun/ui';
+import DirectProfileCard from '../DirectProfileCard';
+import { withSuspense } from '@/hocs/withSuspense';
+
+const DirectProfileList = () => {
+  return (
+    <StyledDirectProfileList direction="horizontal" align="center" spacing={20}>
+      <DirectProfileCard
+        profileId={5}
+        userId={4}
+        introduction={`- 부마위키, 식견의 백엔드 팀장이에요.\n- 트레이드 오프에 관한 토론을 좋아해요.`}
+      />
+      <DirectProfileCard
+        profileId={15}
+        userId={1}
+        introduction={`- 당근 인턴 경험이 있어요.\n- 마루와 식견의 프론트엔드 팀장이에요.\n- 오픈소스에 기여하는 것을 좋아해요.`}
+      />
+      <DirectProfileCard
+        profileId={13}
+        userId={9}
+        introduction={`- 부마위키에서 PM 및 프론트엔드 팀장을\n담당했어요.\n- 클린 코드와 기술 동향에 대해 관심이\n있어요.`}
+      />
+      <DirectProfileCard
+        profileId={3}
+        userId={3}
+        introduction={`- 마루, 식견의 디자인을 맡았어요\n- 디자인과 디자이너 취업 등에 대해 이야기\n해드릴 수 있어요`}
+      />
+    </StyledDirectProfileList>
+  );
+};
+
+export default withSuspense(DirectProfileList);
+
+const StyledDirectProfileList = styled(Stack)`
+  width: 100%;
+  height: 180px;
+`;

--- a/apps/client/src/components/profile/ProfileCard/index.tsx
+++ b/apps/client/src/components/profile/ProfileCard/index.tsx
@@ -15,7 +15,6 @@ type ProfileCardProps = {
   userId: number;
   company?: string;
   introduction?: string;
-  isRecruited: boolean;
 };
 
 const ProfileCard = ({
@@ -27,7 +26,6 @@ const ProfileCard = ({
   userId,
   company,
   introduction,
-  isRecruited,
 }: ProfileCardProps) => {
   const overlay = useOverlay();
   const { logClickEvent } = useLogAnalyticsEvent();
@@ -61,14 +59,14 @@ const ProfileCard = ({
             </Text>
           </Stack>
           {introduction && (
-            <Text fontType="p2" color="gray600" isEllipsis={true}>
+            <Text fontType="p2" color="gray600">
               {introduction.length === 20 ? introduction + '...' : introduction}
             </Text>
           )}
           <Stack direction="horizontal" spacing={6} align="center">
             <Image src="/assets/svgs/company.svg" width={16} height={16} alt="Company" />
             <Text fontType="body2" color="gray600">
-              {isRecruited ? company : '부산소프트웨어마이스터고등학교'}
+              {company ? company : '부산소프트웨어마이스터고등학교'}
             </Text>
           </Stack>
         </Stack>

--- a/apps/client/src/components/profile/ProfileList/index.tsx
+++ b/apps/client/src/components/profile/ProfileList/index.tsx
@@ -24,7 +24,6 @@ const ProfileList = ({ major }: ProfileListProps) => {
             imageUrl={profile.imageUrl}
             cardinal={profile.cardinal}
             major={profile.major}
-            isRecruited={profile.isRecruited}
             profileId={profile.id}
             userId={profile.userId}
             company={profile.company}

--- a/packages/design-token/src/font.ts
+++ b/packages/design-token/src/font.ts
@@ -3,8 +3,6 @@ import { css } from '@emotion/react';
 export const FontCSS = css`
   @font-face {
     font-family: 'WantedSansVariable';
-    font-style: normal;
-    font-weight: normal;
     src: url('/fonts/WantedSansVariable.woff2') format('woff2');
   }
 `;

--- a/packages/ui/src/Text/index.tsx
+++ b/packages/ui/src/Text/index.tsx
@@ -1,4 +1,3 @@
-import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { type ColorKeys, type FontKeys } from '@sickgyun/design-token';
 import {
@@ -13,7 +12,6 @@ export type TextProps = {
   tag?: 'p' | 'span';
   color?: ColorKeys;
   children: ReactNode;
-  isEllipsis?: boolean;
 } & HTMLAttributes<HTMLSpanElement>;
 
 export const Text = forwardRef(function Text(
@@ -22,20 +20,12 @@ export const Text = forwardRef(function Text(
     children,
     fontType: textStyle = 'p1',
     color = 'gray900',
-    isEllipsis = false,
     ...props
   }: TextProps,
   ref: ForwardedRef<HTMLSpanElement>
 ) {
   return (
-    <StyledText
-      ref={ref}
-      as={tag}
-      color={color}
-      fontType={textStyle}
-      isEllipsis={isEllipsis}
-      {...props}
-    >
+    <StyledText ref={ref} as={tag} color={color} fontType={textStyle} {...props}>
       {children}
     </StyledText>
   );
@@ -44,15 +34,7 @@ export const Text = forwardRef(function Text(
 const StyledText = styled.span<{
   color: ColorKeys;
   fontType: FontKeys;
-  isEllipsis: boolean;
 }>`
   color: ${({ color, theme }) => color && theme.colors[color]};
   ${({ theme, fontType }) => theme.fonts[fontType]};
-  ${({ isEllipsis }) =>
-    isEllipsis &&
-    css`
-      overflow: hidden;
-      white-space: nowrap;
-      text-overflow: ellipsis;
-    `}
 `;


### PR DESCRIPTION
## ⛳️작업 내용
- 메인 페이지에 다이렉트 프로필 리스트 섹션 추가
- 다이렉트 프로필 카드 개발
- 디이렉트 프로필 리스트 개발
- 프로필 굵기 적용이 되지 않는 버그 수정
- 프로필 등록시 회사를 적었을 경우 프로필 카드에서 회사 이름이 보이도록 수정
<!-- 작업한 사항을 간략하게 적어주세요 -->

## 📸스크린샷
<img width="1344" alt="image" src="https://github.com/sickgyun/sickgyun-client/assets/102217654/122a0f13-71a0-417a-8f47-faf1be83cc71">
<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## 📎레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->
