### PR TITLE
fix(client): 모달 -> 프로필 수정 페이지로 이동시 스크롤이 되지 않는 이슈 수정

### DIFF
--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -63,7 +63,6 @@ const StyledProfilePage = styled.div`
   flex-direction: column;
   margin: 0 auto;
   width: 80%;
-  padding-top: 100px;
-  padding-bottom: 32px;
+  padding-top: 32px;
   margin-bottom: 48px;
 `;

--- a/apps/web/src/components/profile/ProfileDetailModal/index.tsx
+++ b/apps/web/src/components/profile/ProfileDetailModal/index.tsx
@@ -49,6 +49,7 @@ const ProfileDetailModal = ({
   };
 
   const handleGoProfileUpdatePage = () => {
+    onClose();
     router.push('/profile/update');
   };
 

--- a/packages/ui/src/Modal/Modal.tsx
+++ b/packages/ui/src/Modal/Modal.tsx
@@ -7,6 +7,7 @@ type ModalProps = {
   isOpen: boolean;
   onClose: VoidFunction;
   children: ReactNode;
+  isRender?: boolean;
 } & HTMLAttributes<HTMLDivElement>;
 
 export const Modal = forwardRef(function Modal(
@@ -14,8 +15,10 @@ export const Modal = forwardRef(function Modal(
   ref: ForwardedRef<HTMLDivElement>
 ) {
   const onClickOutside: MouseEventHandler<HTMLDivElement> = (e) => {
-    if (e.target !== e.currentTarget) return;
-    if (onClose) onClose();
+    if (e.target !== e.currentTarget) {
+      return;
+    }
+    onClose();
   };
 
   useEffect(() => {

--- a/packages/ui/src/Modal/Modal.tsx
+++ b/packages/ui/src/Modal/Modal.tsx
@@ -7,7 +7,6 @@ type ModalProps = {
   isOpen: boolean;
   onClose: VoidFunction;
   children: ReactNode;
-  isRender?: boolean;
 } & HTMLAttributes<HTMLDivElement>;
 
 export const Modal = forwardRef(function Modal(

--- a/packages/ui/src/Switch/index.tsx
+++ b/packages/ui/src/Switch/index.tsx
@@ -63,6 +63,7 @@ const StyledSwitchButton = styled.button<{ isActive: boolean }>`
 
     ${isActive &&
     css`
+      font-weight: 600;
       color: ${theme.colors.primary};
     `}
   `}


### PR DESCRIPTION
## ⛳️작업 내용
- 모달 -> 프로필 수정 페이지로 이동시 스크롤이 되지 않는 이슈 수정
   - 문제 설명: 전에 작업했던 모달을 띄웠을 시에 백그라운드 스크롤이 되지 않도록 하는 작업을 했었어요 해당 작업이 추가됨과 동시에 기존 useOverlay가 모달을 연 상태로 다른 페이지로 이동했을때 isOpen이 false로 변경 되지 않는 것이 문제가 되는 것이었어요 우선은 현재 useOverlay를 toss slash 라이브러리에 의존하고 있기도 하고 페이지 이동시 모달을 닫아주는 것 또한 이론적으로 맞다고 생각하여  다른 방안을 생각하지 않고 해당 문제만 해결하는 방향으로 작업을 했어요.
- 스위치 액티브시 폰트 굵기 변경 추가

<!-- 작업한 사항을 간략하게 적어주세요 -->

## 📸스크린샷

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## 📎레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->
